### PR TITLE
Added parallel migration threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,17 @@ Note that you can disable the default migrating of all tenants with `db:migrate`
 `Apartment.db_migrate_tenants = false` in your `Rakefile`. Note this must be done
 *before* the rake tasks are loaded. ie. before `YourApp::Application.load_tasks` is called
 
+#### Parallel Migrations
+
+Apartment supports parallelizing migrations into multiple threads when
+you have a large number of tenants. By default, parallel migrations is
+turned off. You can enable this by setting `parallel_migration_threads` to 
+the number of threads you want to use in your initializer.
+
+Keep in mind that because migrations are going to access the database,
+the number of threads indicated here should be less than the pool size
+that Rails will use to connect to your database.
+
 ### Handling Environments
 
 By default, when not using postgresql schemas, Apartment will prepend the environment to the tenant name

--- a/apartment.gemspec
+++ b/apartment.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord',    '>= 3.1.2', '< 6.0'
   s.add_dependency 'rack',            '>= 1.3.6'
   s.add_dependency 'public_suffix',   '~> 2.0.5'
+  s.add_dependency 'parallel',        '>= 0.7.1', '< 1.20.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rake',         '~> 0.9'

--- a/lib/apartment.rb
+++ b/lib/apartment.rb
@@ -11,7 +11,7 @@ module Apartment
     extend Forwardable
 
     ACCESSOR_METHODS  = [:use_schemas, :use_sql, :seed_after_create, :prepend_environment, :append_environment, :with_multi_server_setup ]
-    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file]
+    WRITER_METHODS    = [:tenant_names, :database_schema_file, :excluded_models, :default_schema, :persistent_schemas, :connection_class, :tld_length, :db_migrate_tenants, :seed_data_file, :parallel_migration_threads]
 
     attr_accessor(*ACCESSOR_METHODS)
     attr_writer(*WRITER_METHODS)
@@ -53,6 +53,10 @@ module Apartment
     end
     alias :default_tenant :default_schema
     alias :default_tenant= :default_schema=
+
+    def parallel_migration_threads
+      @parallel_migration_threads || 0
+    end
 
     def persistent_schemas
       @persistent_schemas || []

--- a/lib/tasks/apartment.rake
+++ b/lib/tasks/apartment.rake
@@ -1,4 +1,5 @@
 require 'apartment/migrator'
+require 'parallel'
 
 apartment_namespace = namespace :apartment do
 
@@ -17,7 +18,7 @@ apartment_namespace = namespace :apartment do
   desc "Migrate all tenants"
   task :migrate do
     warn_if_tenants_empty
-    tenants.each do |tenant|
+    each_tenant do |tenant|
       begin
         puts("Migrating #{tenant} tenant")
         Apartment::Migrator.migrate tenant
@@ -31,7 +32,7 @@ apartment_namespace = namespace :apartment do
   task :seed do
     warn_if_tenants_empty
 
-    tenants.each do |tenant|
+    each_tenant do |tenant|
       begin
         puts("Seeding #{tenant} tenant")
         Apartment::Tenant.switch(tenant) do
@@ -49,7 +50,7 @@ apartment_namespace = namespace :apartment do
 
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
 
-    tenants.each do |tenant|
+    each_tenant do |tenant|
       begin
         puts("Rolling back #{tenant} tenant")
         Apartment::Migrator.rollback tenant, step
@@ -67,7 +68,7 @@ apartment_namespace = namespace :apartment do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required' unless version
 
-      tenants.each do |tenant|
+      each_tenant do |tenant|
         begin
           puts("Migrating #{tenant} tenant up")
           Apartment::Migrator.run :up, tenant, version
@@ -84,7 +85,7 @@ apartment_namespace = namespace :apartment do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       raise 'VERSION is required' unless version
 
-      tenants.each do |tenant|
+      each_tenant do |tenant|
         begin
           puts("Migrating #{tenant} tenant down")
           Apartment::Migrator.run :down, tenant, version
@@ -103,6 +104,12 @@ apartment_namespace = namespace :apartment do
         apartment_namespace['rollback'].invoke
         apartment_namespace['migrate'].invoke
       end
+    end
+  end
+
+  def each_tenant(&block)
+    Parallel.each(tenants, in_threads: Apartment.parallel_migration_threads) do |tenant|
+      block.call(tenant)
     end
   end
 


### PR DESCRIPTION
Using 'parallel' version less than '1.20.0' for now as later versions need ruby version 2.4 or more.
The current ruby version for HF Retro/Scout is 2.3.3